### PR TITLE
Install jq instead of relying on it being present

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A github action to parse and output default version of F3D dependencies
 
-Needs `jq`.
+Installs `jq` using `sudo` and `apt`.

--- a/action.yml
+++ b/action.yml
@@ -56,11 +56,13 @@ runs:
 
     - name: Check required inputs
       shell: bash
-      run: |
-        [[ "${{ inputs.file }}" ]] || { echo "file input is empty" ; exit 1; }
+      run: [[ "${{ inputs.file }}" ]] || { echo "file input is empty" ; exit 1; }
+
+    - name: Install jq
+      shell: bash
+      run: sudo apt install -y jq
 
     - name: Read JSON file
       id: parse_file
       shell: bash
-      run: |
-        echo "json=$(jq -c . < ${{ inputs.file }})" >> $GITHUB_OUTPUT
+      run: echo "json=$(jq -c . < ${{ inputs.file }})" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Installing `jq` takes 6s instead of 34s when pulling f3d-ci docker images.